### PR TITLE
Fixes AutoLayout

### DIFF
--- a/KMPlaceholderTextView/KMPlaceholderTextView.swift
+++ b/KMPlaceholderTextView/KMPlaceholderTextView.swift
@@ -114,15 +114,6 @@ public class KMPlaceholderTextView: UITextView {
             options: [],
             metrics: nil,
             views: ["placeholder": placeholderLabel])
-        newConstraints.append(NSLayoutConstraint(
-            item: placeholderLabel,
-            attribute: .Width,
-            relatedBy: .Equal,
-            toItem: self,
-            attribute: .Width,
-            multiplier: 1.0,
-            constant: -(textContainerInset.left + textContainerInset.right + textContainer.lineFragmentPadding * 2.0)
-            ))
         removeConstraints(placeholderLabelConstraints)
         addConstraints(newConstraints)
         placeholderLabelConstraints = newConstraints


### PR DESCRIPTION
If the priority of the width constraint isn't reduced it is automatically broken. Running this without the priority lowered generates a string of warnings in the console log, meaning that this is being over constrained.