### PR TITLE
Layout fix: labels doesn't need constraints on booth sides.

### DIFF
--- a/KMPlaceholderTextView/KMPlaceholderTextView.swift
+++ b/KMPlaceholderTextView/KMPlaceholderTextView.swift
@@ -109,19 +109,12 @@ public class KMPlaceholderTextView: UITextView {
                 "left" : textContainerInset.left + textContainer.lineFragmentPadding,
             ],
             views: ["placeholder": placeholderLabel])
-        newConstraints += NSLayoutConstraint.constraintsWithVisualFormat("V:|-(\(textContainerInset.top))-[placeholder]",
+        newConstraints += NSLayoutConstraint.constraintsWithVisualFormat("V:|-top-[placeholder]",
             options: [],
-            metrics: nil,
+            metrics: [
+                "top" : textContainerInset.top,
+            ],
             views: ["placeholder": placeholderLabel])
-        newConstraints.append(NSLayoutConstraint(
-            item: placeholderLabel,
-            attribute: .Width,
-            relatedBy: .Equal,
-            toItem: self,
-            attribute: .Width,
-            multiplier: 1.0,
-            constant: -(textContainerInset.left + textContainerInset.right + textContainer.lineFragmentPadding * 2.0)
-            ))
         removeConstraints(placeholderLabelConstraints)
         addConstraints(newConstraints)
         placeholderLabelConstraints = newConstraints

--- a/KMPlaceholderTextView/KMPlaceholderTextView.swift
+++ b/KMPlaceholderTextView/KMPlaceholderTextView.swift
@@ -103,14 +103,13 @@ public class KMPlaceholderTextView: UITextView {
     }
     
     private func updateConstraintsForPlaceholderLabel() {
-        var newConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-left-[placeholder]-right-|",
+        var newConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-left-[placeholder]",
             options: [],
             metrics: [
                 "left" : textContainerInset.left + textContainer.lineFragmentPadding,
-                "right" : textContainerInset.right + textContainer.lineFragmentPadding
             ],
             views: ["placeholder": placeholderLabel])
-        newConstraints += NSLayoutConstraint.constraintsWithVisualFormat("V:|-(\(textContainerInset.top))-[placeholder]-(>=\(textContainerInset.bottom))-|",
+        newConstraints += NSLayoutConstraint.constraintsWithVisualFormat("V:|-(\(textContainerInset.top))-[placeholder]",
             options: [],
             metrics: nil,
             views: ["placeholder": placeholderLabel])


### PR DESCRIPTION
Labels requires only one horizontal and one vertical constraint.
Try replace textview's bottom constraint with height constraint, and IB will generate warning. Removing tail and bottom constraints will fix that.